### PR TITLE
Fixes many dependency errors

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -2,7 +2,7 @@ altair==4.1.0
 beautifulsoup4==4.9.1
 bokeh==2.0.2
 bqplot==0.12.7
-ccxt==1.21.22
+ccxt==1.23.1
 chart-studio==1.1.0
 dash==1.12.0
 dash-core-components==1.10.0
@@ -27,7 +27,7 @@ mimesis==3.3.0
 nbdime==2.0.0
 nbresuse==0.3.6
 numba==0.46.0
-numpy==1.18.3
+numpy==1.21.2
 openpyxl==3.0.3
 pandas==0.25.3
 pandoc==1.0.2
@@ -48,10 +48,10 @@ spacy==2.2.4
 SQLAlchemy==1.3.6
 statsmodels==0.10.1
 sympy==1.5.1
-tensorboard==2.2.2
+tensorboard==2.5.0
 tensorboard-plugin-wit==1.6.0.post3
 tensorflow==2.5.1
-tensorflow-estimator==2.2.0
+tensorflow-estimator==2.5.0
 vapeplot==0.0.8
 vega==2.5.0
 voila==0.1.21


### PR DESCRIPTION
fix broken ccxt dependancy
`1.21.22 doesn't exist (https://pypi.org/project/ccxt/1.23.1/#history)`

fixes numpy version

fix broken tensorboard dependancy

```
ERROR: Cannot install -r binder/requirements.txt (line 53) and tensorboard==2.2.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested tensorboard==2.2.2
    tensorflow 2.5.1 depends on tensorboard~=2.5
```
fixes broken tensorflow-estimator version