### PR TITLE
Remove version requirements to allow pip to dynamically decide on what version to install based on other packages

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -4,7 +4,7 @@ bokeh
 bqplot
 ccxt
 chart-studio
-dash==
+dash
 dash-core-components
 dash-html-components
 dash-renderer


### PR DESCRIPTION
Remove version requirements to allow pip to dynamically decide on what version to install based on other packages, by doing this prevents build error

pip has a feature that allows it to solve dependency conflicts

From pip install error:

`Remove version requirements to allow pip to dynamically decide on what version to install based on other packages`