### PR TITLE
Update 4_webapi.ipynb

### DIFF
--- a/notebooks/4_webapi.ipynb
+++ b/notebooks/4_webapi.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "url = f'{coindeskURL}start={start:%Y-%m-%d}&end={end:%Y-%m-%d}'\n",
     "\n",
-    "print(f'Hitting this url:{url}')\n",
+    "print(f'Hitting this url: {url}')\n",
     "\n",
     "result = requests.get(url)\n",
     "result.content"


### PR DESCRIPTION
enhanced the readability of code by giving a space after colon ":" print(f'Hitting this url:  {url}')