### PR TITLE
Bump version of perspective-jupyterlab to fix issue with binder not loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Overview
 This course is designed to be an introduction to numerical computing and data visualization in Python. It is not designed to be a complete course in Computer Science or programming, but rather a motivational demonstration of how relatively complex topics can be accessible even to those without formal progamming backgrounds.
 
-This training is designed to be conducted in-person, led by J.P. Morgan technologists and traders. For interested institutional clients, please reach out [via email](mailto:open_source@jpmorgan.com)
+This training is designed to be conducted in-person, led by J.P. Morgan technologists and traders. For interested institutional clients, please contact your J.P. Morgan team.
 
 [![](https://img.shields.io/badge/Launch-Cloud%20Instance-brightgreen?style=for-the-badge)](http://mybinder.org/v2/gh/jpmorganchase/python-training/main?urlpath=lab)
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,7 +2,7 @@
 export NODE_OPTIONS=--max-old-space-size=2048
 
 EXTENSIONS="
-@finos/perspective-jupyterlab@1.3.11
+@finos/perspective-jupyterlab@2.3.1
 "
 
 until jupyter labextension install $EXTENSIONS --no-build


### PR DESCRIPTION
Fixes issue with broken binder by bumping versions of finos/perspective-jupyterlab. See #66 and test at [https://mybinder.org/v2/gh/brooklynrob/python-training/main?urlpath=lab](https://mybinder.org/v2/gh/brooklynrob/python-training/main?urlpath=lab)